### PR TITLE
fix: remove sightings from session-storage preventing successful auth (issue #14)

### DIFF
--- a/src/client/src/main.js
+++ b/src/client/src/main.js
@@ -529,7 +529,7 @@ export const store = new Vuex.Store(
             console.log(e)
         }
       },
-      get_sightings({commit}) {
+      get_sightings() {
         return new Promise( (resolve,reject) => {
           let requestAuth = {}
           let endpoint
@@ -553,7 +553,6 @@ export const store = new Vuex.Store(
             // Add list of users into the store of user requests
             .then( sightings => {
               resolve(sightings.data)
-              commit('setSightings', sightings.data)
             })
             .catch(err => {
               console.error(err)


### PR DESCRIPTION
Saving all the sightings data in session storage was exceeding the capacity of the browser. This was causing issues, preventing user access tokens from being saved and preventing the download of the .csv file.  