### PR TITLE
fix: easy marker selection

### DIFF
--- a/src/client/src/components/MapComponent.vue
+++ b/src/client/src/components/MapComponent.vue
@@ -267,14 +267,14 @@ export default {
                   },
                   //minzoom: 14,
                   paint: {
-                    // Set size of circle pinpoint based on how large the sighting is (all made same size for now, was 0 4 5 12)
+                    // Set size of circle pinpoint based on how large the sighting is
                     'circle-radius': [
                       'interpolate',
-                      ['linear'],
-                      ['to-number', ['get', 'no_sighted']],
-                      0, 5,
-                      5, 5
-                    ],
+                       ['linear'], ['zoom'],
+                    6, 6,
+                    8, 10,
+                    10, 14
+                  ],
                     // Set colour of circle pinpoint based of number of sightings
                     'circle-color': [
                       'interpolate',


### PR DESCRIPTION
This commit marginally increases the size of the markers.
![image](https://github.com/salish-sea/acartia/assets/96722504/b8389d0f-a377-4b71-aba4-5e19fadafd0e)

And then incrementally increases the size as you zoom in to allow for easier selection.
![image](https://github.com/salish-sea/acartia/assets/96722504/015d0f4c-832a-4597-851c-ee43d5163521)
