### PR TITLE
fix: landing page text (#10)

### DIFF
--- a/src/client/src/components/Pages/HomePage.vue
+++ b/src/client/src/components/Pages/HomePage.vue
@@ -5,7 +5,7 @@
             <h1>Acartia</h1>
           <div class="text-left">
             <p>
-              A decentralized data cooperative for sharing marine animal locations within the Salish Sea.
+              A decentralized data cooperative for sharing marine animal locations within the Salish Sea and across coastal Cascadia.
               Let’s work together to monitor and map marine wildlife -- from plankton to orcas!
             </p>
             <p>


### PR DESCRIPTION
Landing page modal text changed from "within the Salish Sea" to "within the Salish Sea and across coastal Cascadia".
