### PR TITLE
fix: update homepage responsiveness (#54)

### DIFF
--- a/src/client/src/components/MapComponent.vue
+++ b/src/client/src/components/MapComponent.vue
@@ -1,17 +1,17 @@
 <template>
     <div>
-        <div id='mapContainer'></div>
+        <div id='mapContainer'>
         <div id='widget'>
           <div v-if="getParent !== 'Heatmap'">
-            <h2>Observation Age</h2>
+            <h2 class="header" >Observation Age</h2>
             <div class='widget-row colors'></div>
             <div class='widget-row labels'>
-                <div class='label'>	&#60; 1 day</div>
-                <div class='label'>	&#60; 2 days</div>
-                <div class='label'>	&#60; 3 days</div>
-                <div class='label'>	&#60; 4 days</div>
-                <div class='label'>	&#60; 5 days</div>
-                <div class='label'>&#62; 5 days</div>
+            <div class='label'><span class='day-container'>&#60; 1 day&#32;</span></div>
+            <div class='label'><span class='day-container'>&#60; 2 days</span></div>
+            <div class='label'><span class='day-container'>&#60; 3 days</span></div>
+            <div class='label'><span class='day-container'>&#60; 4 days</span></div>
+            <div class='label'><span class='day-container'>&#60; 5 days</span></div>
+            <div class='label'><span class='day-container'>&#62; 5 days</span></div>
             </div>
             <br>
             <div v-if="isAuth && getParent === 'Visualiser'" class='slider-class' id='sliderbar'>
@@ -21,7 +21,7 @@
             </div>
           </div>
           <div v-else-if="isAuth && getParent === 'Heatmap'">
-            <h2>Historical Sightings</h2>
+            <h2 class="header" >Historical Sightings</h2>
             <br>
             <div class='slider-class' id='sliderbar'>
               <p>Sightings: <label id='active-date'>January-March 2020</label></p>
@@ -35,6 +35,7 @@
             </div>
           </div>
         </div>
+    </div>
     </div>
 </template>
 
@@ -462,6 +463,7 @@ export default {
     height: 100%;
     margin: 0 auto;
     position: relative;
+    z-index:0;
 }
 
 #active-date {
@@ -469,14 +471,18 @@ export default {
 }
 
 #widget {
-    position: fixed;
+    position: relative;
     width: 30%;
-    top: 6vh;
-    left: 1vh;
+    top: 1vw;
+    left: 1vw;
     margin: 10px;
     padding: 10px 20px;
     background-color: white;
-    position: absolute;
+    z-index: 1;
+}
+
+.header {
+  font-size: 2.0vw;
 }
 
 .slider-class {
@@ -497,5 +503,9 @@ export default {
   width: 15%;
   display: inline-block;
   text-align: center;
+}
+
+.day-label {
+  font-size:calc(6px + 0.5vw);
 }
 </style>


### PR DESCRIPTION
## Problem
the responsive navbar design is obfuscated by the 'observation age' dialog when expanded. Additionally, the text in the dialog overlaps on smaller screens. <br>
![image](https://github.com/salish-sea/acartia/assets/96722504/5f75bd2a-30c1-498c-a89b-146d68c6fbb9)<br>
![image](https://github.com/salish-sea/acartia/assets/96722504/3476b721-5809-453a-a091-025386cd37b9)<br>
![image](https://github.com/salish-sea/acartia/assets/96722504/2944b47c-72ad-4172-9182-d18a7bb992e7)<br><br>

## Update

with this commit, the dialog box moves with the expanding navbar. <br>
![image](https://github.com/salish-sea/acartia/assets/96722504/c889f6fd-e222-4805-af29-d2a77b49d818)<br>

Also, all text in the dialog now scales proportional to the viewport width.<br>

![image](https://github.com/salish-sea/acartia/assets/96722504/261834bb-35c4-4183-9af4-b68bd1bb5ba6)<br>
![image](https://github.com/salish-sea/acartia/assets/96722504/4e6fe55e-e67a-428f-a40e-45f3a274a0d3)<br>

