### PR TITLE
fix off by one error and remove magic numbers

### DIFF
--- a/src/client/src/constants.js
+++ b/src/client/src/constants.js
@@ -3,7 +3,7 @@ import { getNDaysAgo } from './dateUtils'
 export const ALL_SPECIES = "allSpecies"
 export const ALL_CONTRIBUTORS = "allContributors"
 
-export function generateInitFilterState(startNDaysAgo, endNDaysAgo) {
+export function generateInitFilterState({startNDaysAgo, endNDaysAgo}={}) {
   return {
     dateBegin: getNDaysAgo(startNDaysAgo),
     dateEnd: getNDaysAgo(endNDaysAgo),

--- a/src/client/src/store.js
+++ b/src/client/src/store.js
@@ -23,7 +23,7 @@ const store = createStore(
       error: null,
 
       //Map state
-      mapFilters: generateInitFilterState(7, 1),
+      mapFilters: generateInitFilterState({startNDaysAgo : 6, endNDaysAgo : 0}),
       mapOptions: {
         contributors: [],
         species: [],
@@ -36,7 +36,7 @@ const store = createStore(
       hydrophonesVisibility: 'none',
 
       // Table view state
-      tableFilters: generateInitFilterState(1, 1),
+      tableFilters: generateInitFilterState({startNDaysAgo : 0, endNDaysAgo : 0}),
       tableSightings: [],
 
       // Notifications
@@ -135,7 +135,7 @@ const store = createStore(
         }
       },
       resetMapFilters(state) {
-        state.mapFilters = generateInitFilterState(7, 1)
+        state.mapFilters = generateInitFilterState({startNDaysAgo : 6, endNDaysAgo : 0})
         state.filteredSightings = filterSightingData(state.sightings, state.mapFilters)
 
         //Rerender map


### PR DESCRIPTION
Fix for default date filtering off-by-one error mentioned in monday/tuesdays meeting, before it was configured to be the range of 1 day ago to 7 days ago, as I am writing this the current date is 17/01/2025, so this date range comes out to be 16/01/2025 (1 day ago) to 10/01/2025 (7 days ago), I have changed this to be the range of 0 days ago to 6 days ago, which maintains the desired 7 day range but starting from "today" instead of yesterday. 

Also changed function parameters of 'generateInitFilterState' to keyword arguments to improve readability.

#70 