### PR TITLE
improve map colors

### DIFF
--- a/src/client/src/components/MapFilterComponent.vue
+++ b/src/client/src/components/MapFilterComponent.vue
@@ -235,7 +235,12 @@ export default {
     },
     speciesLegendOptions: {
       get() {
-        return this.$store.getters.getSpeciesLegendOptions
+        // Sort alphabetically to group different spellings of species field
+        // eg. "Killer Whale" and "killer whale" and "killer whale sighting"
+        // this is a temporary hack until the database schema is revised (species enumerated types?)
+        let legendOptions = this.$store.getters.getSpeciesLegendOptions;
+        let legendOptionsSorted = legendOptions.sort()
+        return legendOptionsSorted;
       },
     },
     species: {

--- a/src/client/src/mapUtils.js
+++ b/src/client/src/mapUtils.js
@@ -259,86 +259,150 @@ export function filterTableData(sightingData, filterObj) {
   return sightingData
 }
 
-
-
-
 export const legendColorMap = {
-  "Atlantic White-sided Dolphin": "#FF5733",
-  "Atlantic White-sided Dolphin Sighting:": "#FF8D1A",
-  "Autre": "#FFC300",
-  "Baird's Beaked Whale": "#DAF7A6",
-  "Beluga": "#33FF57",
-  "Beluga Whale": "#33FFBF",
-  "Beluga Whale Sighting:": "#33A1FF",
-  "black right whale": "#337BFF",
-  "Blue Shark": "#8A2BE2",
-  "Blue Whale": "#7B33FF",
-  "Blue Whale Sighting:": "#6A5ACD",
-  "Bottlenose Dolphin": "#FF33F6",
-  "Bottlenose Whale": "#FF33A1",
-  "Common Dolphin": "#FF5733",
-  "Common Dolphin - Unidentified": "#FF8D1A",
-  "Common Dolphin Sighting:": "#FFC300",
-  "Common Long-Beaked Dolphin": "#DAF7A6",
-  "Common Short-Beaked Dolphin": "#33FF57",
-  "Dall's Porpoise": "#33FFBF",
-  "Dall\\'s Porpoise": "#33A1FF",
-  "Fin Whale": "#337BFF",
-  "Fin Whale Sighting:": "#8A2BE2",
-  "Finback Whale": "#7B33FF",
-  "Gray Whale": "#6A5ACD",
-  "Gray Whale Sighting:": "#FF33F6",
-  "Grey": "#FF33A1",
-  "grey whale": "#FF5733",
-  "Harbor Porpoise": "#FF8D1A",
+  // Magenta
+  "Atlantic White-sided Dolphin": "#FF00FF", 
+  "Atlantic White-sided Dolphin Sighting:": "#FF00FF",
+
+  // BLACK (same as "Other")
+  "Autre": "#000000",
+
+  // Dark Orange
+  "Baird's Beaked Whale": "#FF8C00",
+
+  // Dark Orchid (same as "Right Whale")
+  "black right whale": "#9932CC",
+
+  // Green
+  "Blue Shark": "#00FF00",
+
+  // LIGHT PINK
+  "Beluga": "#FC77DF",
+  "Beluga Whale": "#FC77DF",
+  "Beluga Whale Sighting:": "#FC77DF",
+
+  // Pink
+  "Bottlenose Dolphin": "#FF69B4",
+
+  // Coral
+  "Bottlenose Whale": "#FF7F50",
+
+  // Light Green
+  "Common Dolphin": "#90EE90", 
+  "Common Dolphin - Unidentified": "#90EE90",
+  "Common Dolphin Sighting:": "#90EE90",
+
+  // Yellow Green
+  "Common Short-Beaked Dolphin": "#9ACD32",
+
+  // Violet
+  "Dall's Porpoise": "#EE82EE",
+  "Dall\\'s Porpoise": "#EE82EE",
+
+  // Red
+  "Fin Whale": "#FF0000",
+  "Fin Whale Sighting:": "#FF0000",
+  "Finback Whale": "#FF0000",
+
+  // GREY
+  "Gray Whale": "#787878",
+  "Gray Whale Sighting:": "#787878",
+  "Grey": "#787878",
+  "grey whale": "#787878",
+
+  // CYAN
+  "Harbor Porpoise":"#00EAFF",
+  "Marsouin commun": "#00EAFF",
+
+  // YELLOW
   "Humpback": "#FFC300",
-  "Humpback Sighting:": "#DAF7A6",
-  "Humpback Whale": "#33FF57",
-  "Killer Whale": "#33FFBF",
+  "Humpback Sighting:": "#FFC300",
+  "Humpback Whale": "#FFC300",
+
+  // BLUE
+  "Killer Whale": "#33A1FF",
   "Killer Whale (Orca)": "#33A1FF",
-  "Killer Whale (Orca) Sighting:": "#337BFF",
-  "Killer Whale Sighting:": "#8A2BE2",
-  "long-beaked common dolphin": "#7B33FF",
-  "Long-beaked Common Dolphin": "#6A5ACD",
-  "Marsouin commun": "#FF33F6",
-  "Minke Whale": "#FF33A1",
+  "Killer Whale (Orca) Sighting:": "#33A1FF",
+  "Killer Whale Sighting:": "#33A1FF",
+  "Southern Resident Killer Whale": "#33A1FF",
+  "Southern Resident Killer Whale Sighting:": "#33A1FF",
+  "Southern Resident Orca": "#33A1FF",
+
+  // Medium Sea Green
+  "Common Long-Beaked Dolphin": "#3CB371",
+  "long-beaked common dolphin": "#3CB371",
+  "Long-beaked Common Dolphin": "#3CB371",
+
+  // ORANGE SODA
+  "Minke Whale": "#FF5733",
   "Minke Whale Sighting:": "#FF5733",
-  "Mola Mola / Sunfish": "#FF8D1A",
-  "Non spÃ©cifiÃ©": "#FFC300",
-  "Non spécifié": "#DAF7A6",
-  "Northern Right Whale Dolphin": "#33FF57",
-  "Northern Right Whale Dolphin Sighting:": "#33FFBF",
+  "Petit rorqual": "#FF5733",
+
+  // Teal
+  "Mola Mola / Sunfish": "#008080",
+
+  // LIGHT GREY (same as "Unspecified")
+  "Non spÃ©cifiÃ©": "#F5EBF3",
+  "Non spécifié": "#F5EBF3",
+
+  // Gold
+  "Northern Right Whale Dolphin": "#FFD700",
+  "Northern Right Whale Dolphin Sighting:": "#FFD700",
+
+  // DARK BLUE
+  "Blue Whale": "#0E0299",
+  "Blue Whale Sighting:": "#0E0299",
+
+  // BLUE 
   "Orca": "#33A1FF",
-  "Orca Sighting:": "#337BFF",
-  "Other": "#8A2BE2",
-  "Other (Specify in comments)": "#7B33FF",
-  "Other (Specify in comments) Sighting:": "#6A5ACD",
-  "Other Sighting:": "#FF33F6",
-  "Other Species": "#FF33A1",
-  "Pacific White-Sided Dolphin": "#FF5733",
-  "Pacific White-sided Dolphin": "#FF8D1A",
-  "Pacific White-sided Dolphin Sighting:": "#FFC300",
-  "Petit rorqual": "#DAF7A6",
-  "Right Whale": "#33FF57",
-  "Right Whale Sighting:": "#33FFBF",
-  "Risso's Dolphin": "#33A1FF",
-  "Risso's Dolphin Sighting:": "#337BFF",
-  "Risso\\'s Dolphin": "#8A2BE2",
-  "Sei Whale": "#7B33FF",
-  "Short Finned Pilot Whale": "#6A5ACD",
-  "Short Finned Pilot Whale Sighting:": "#FF33F6",
-  "Southern Resident Killer Whale": "#FF33A1",
-  "Southern Resident Killer Whale Sighting:": "#FF5733",
-  "Southern Resident Orca": "#FF8D1A",
-  "Sowerby's Beaked Whale": "#FFC300",
-  "Sperm Whale": "#DAF7A6",
-  "Sperm Whale Sighting:": "#33FF57",
-  "steller sealion": "#33FFBF",
-  "Striped Dolphin": "#33A1FF",
-  "Unspecified": "#337BFF",
-  "Unspecified Sighting:": "#8A2BE2",
-  "Whale - Unidentified": "#7B33FF"
-};
+  "Orca Sighting:": "#33A1FF",
+
+  // BLACK
+  "Other": "#000000",
+  "Other (Specify in comments)": "#000000",
+  "Other (Specify in comments) Sighting:": "#000000",
+  "Other Sighting:": "#000000",
+  "Other Species": "#000000",
+
+  // LIME GREEN
+  "Pacific White-Sided Dolphin": "#E1FF00", 
+  "Pacific White-sided Dolphin": "#E1FF00", 
+  "Pacific White-sided Dolphin Sighting:": "#E1FF00",
+
+  // Dark Orchid
+  "Right Whale": "#9932CC",
+  "Right Whale Sighting:": "#9932CC",
+
+  // Orchid
+  "Risso's Dolphin": "#DA70D6",
+  "Risso's Dolphin Sighting:": "#DA70D6",
+  "Risso\\'s Dolphin": "#DA70D6",
+
+  // Light Steel Blue
+  "Sei Whale": "#B0C4DE",
+
+  // Dark Slate Blue
+  "Short Finned Pilot Whale": "#483D8B",
+  "Short Finned Pilot Whale Sighting:": "#483D8B",
+
+  // Dark Olive Green
+  "Sowerby's Beaked Whale": "#556B2F",
+
+  // Tomato
+  "Sperm Whale": "#FF6347",
+  "Sperm Whale Sighting:": "#FF6347",
+
+  // Peru
+  "steller sealion": "#CD853F",
+
+  // Light Sky Blue
+  "Striped Dolphin": "#87CEFA",
+
+  // LIGHT GREY
+  "Unspecified": "#F5EBF3",
+  "Unspecified Sighting:": "#F5EBF3",
+  "Whale - Unidentified": "#F5EBF3"
+}; 
 
 const monthPrefixes = {
   Jan: 1,


### PR DESCRIPTION
Attempt to improve the maps colors to make distinguishing between the different species visually easier (previously some of the colors for different species were the same, yet for some different values representing the same species, the colors were different! (eg. Killer Whale, and Killer Whale sighting etc.). 

Due to the large amount of different species and color scarcity, the aforementioned examples have been grouped into one color in the color legend. Feedback would be appreciated as I am only 99% sure I haven't mistakenly assigned the same color to two separated species which I have interpreted as them same species (I assumed Orca is the same as Killer Whale).

I have also assigned "Southern Resident Orca" to be the same color as "Orca", which may not be appropriate. 

I think this should be viewed as temporary, I'm not sure what revising the database schema will entail exactly but I think it might be beneficial to have a set of pre-defined categories of species and an 'other' category instead of a string, this would consolidate entries with the species "Killer Whale" and "Killer Whale Sighting" into one category in the map filter controls. There would also be opportunity to utilize shapes (other than circle) or a secondary color to communicate different whale pods or sub-species on the map (I am not sure exactly what would make sense here). An example of what this may look like is up on the Acartia Redesign Figma. 

Here is an example (not all species visible in the legend)

<img width="390" alt="Screenshot 2025-01-24 at 1 42 25 pm" src="https://github.com/user-attachments/assets/1bdf36a1-0d1b-40c9-8f95-b3a21817c50a" />
